### PR TITLE
Wrap Player.prototype.options

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,19 @@
       }
     });
 
+  var oldOptions = videojs.Player.prototype.options;
+  videojs.Player.prototype.options = function() {
+    var options = oldOptions.call(this);
+    if (Object.prototype.toString.call(options.children) === '[object Array]') {
+      for (var i = 0; i < options.children.length; i++) {
+        var childName = options.children[i];
+        options.children[childName] = this.getChild(childName);
+      }
+    }
+
+    return options;
+  };
+
   videojs.round = function(x, y) {
     videojs.log.warn('videojs.round(x, y) is deprecated. Use Number(x.toFixed(y)) instead.');
     return Number(x.toFixed(y));

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-qunit": "^0.1.5",
     "qunitjs": "^1.19.0",
-    "video.js": "^5.0.0-rc.90"
+    "video.js": "^5.2.0"
   },
   "scripts": {
     "test": "jshint index.js && karma start test/karma.config.js"


### PR DESCRIPTION
This is necessary because some users relied on the behavior of
options().children to be an object that returned the associated object
but in 5.0 it is now an array for the default components, such as the
player. So, we want to wrap the function to attach the properies of the
children to the children array so both would be available.
